### PR TITLE
Use StrEnum from the standard library if available

### DIFF
--- a/backports/strenum/__init__.py
+++ b/backports/strenum/__init__.py
@@ -1,5 +1,6 @@
 import sys
 from .version import version as __version__  # noqa: F401
+
 if sys.version_info >= (3, 11):
     from enum import StrEnum
 else:

--- a/backports/strenum/__init__.py
+++ b/backports/strenum/__init__.py
@@ -1,4 +1,8 @@
-from .strenum import StrEnum
+import sys
 from .version import version as __version__  # noqa: F401
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from .strenum import StrEnum
 
 __all__ = ["StrEnum"]


### PR DESCRIPTION
This allows people to just import from `backports.strenum` on Python 3.11 and still get the version from the standard library. Otherwise you need the if statement on every import.

I used `if sys.version_info >= (3, 11)` instead of `try: from enum import StrEnum; except ImportError ...` because static type checkers know how to interpret the former, but struggle with the latter. And it seems it won't get fixed. See for example this comment on mypy: https://github.com/python/mypy/issues/1153#issuecomment-1207333806